### PR TITLE
Only check for scheduled buildkite jobs

### DIFF
--- a/pkg/buildkite/client.go
+++ b/pkg/buildkite/client.go
@@ -57,7 +57,7 @@ func watchBuildkiteJobs(ctx context.Context, wg *sync.WaitGroup, client *buildki
 
 		log.Info("Checking Buildkite API for builds and jobs...")
 
-		builds, _, err := client.Builds.ListByPipeline(org, pipeline, &buildkite.BuildsListOptions{})
+		builds, _, err := client.Builds.ListByPipeline(org, pipeline, &buildkite.BuildsListOptions{State: []string{"scheduled", "running"}})
 		if err != nil {
 			log.Error("Error fetching builds from Buildkite API:", err)
 		}


### PR DESCRIPTION
Tested, this fixes builds getting randomly skipped. Cause was that the API sorts by most recently started builds. If you had a 1 month old PR that you retried a single step, it'd be off of the first page of pagination and wouldn't be found.