### PR TITLE
[MEM-34]Add Sentry auth key to Kubekite job template

### DIFF
--- a/job-templates/job.yaml
+++ b/job-templates/job.yaml
@@ -43,6 +43,8 @@ spec:
             valueFrom: {secretKeyRef: {name: expo-account, key: password}}
           - name: MAILOSAUR_KEY
             valueFrom: {secretKeyRef: {name: mailosaur-secret, key: api-key}}
+          - name: SENTRY_AUTH_TOKEN
+            valueFrom: {secretKeyRef: {name: sentry-api, key: token}}
         volumeMounts:
           - name: ssh-keys
             mountPath: /root/.ssh/id_rsa


### PR DESCRIPTION
This secret will allow us to send sourcemaps to sentry, making it more useful for debugging errors with the web and mobile apps.