### PR TITLE
[MEM-1313] Add google-services api key to kubekite

### DIFF
--- a/job-templates/job.yaml
+++ b/job-templates/job.yaml
@@ -47,6 +47,8 @@ spec:
             valueFrom: {secretKeyRef: {name: sentry-api, key: token}}
           - name: SFTP_PASSWORD
             valueFrom: {secretKeyRef: {name: sftp-secret, key: sftp-password}}
+          - name: GOOGLE_SERVICES_API_KEY
+            valueFrom: {secretKeyRef: {name: google-services-api-key, key: api-key}}
         volumeMounts:
           - name: ssh-keys
             mountPath: /root/.ssh/id_rsa


### PR DESCRIPTION
This is needed for push notifications to work with the newer expo SDKs